### PR TITLE
Fixes for loading UPX binaries.

### DIFF
--- a/internal/memloader/loader.go
+++ b/internal/memloader/loader.go
@@ -183,7 +183,11 @@ func (l *Loader) LoadMem(data []byte) (loader.Module, error) {
 		case executable && readable && writable:
 			protect = vmem.PageExecuteReadWrite
 		}
-		err := mem.Protect(uint64(section.VirtualAddress), uint64(section.SizeOfRawData), protect)
+		size := uint64(section.SizeOfRawData)
+		if size == 0 {
+			size = uint64(bin.Header.OptionalHeader.SectionAlignment)
+		}
+		err := mem.Protect(uint64(section.VirtualAddress), size, protect)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/memloader/loader.go
+++ b/internal/memloader/loader.go
@@ -223,14 +223,16 @@ func (l *Loader) LoadMem(data []byte) (loader.Module, error) {
 			dir = dir32.To64()
 		}
 		mem.Seek(int64(dir.AddressOfCallBacks), io.SeekStart)
-		for {
-			mem.Read(b[:psize])
-			addr := binary.LittleEndian.Uint64(b[:])
-			if addr == 0 {
-				break
+		if dir.AddressOfCallBacks != 0 {
+			for {
+				mem.Read(b[:psize])
+				addr := binary.LittleEndian.Uint64(b[:])
+				if addr == 0 {
+					break
+				}
+				cb := l.machine.MemProc(realBase + addr)
+				cb.Call(hinstance, 1, 0)
 			}
-			cb := l.machine.MemProc(realBase + addr)
-			cb.Call(hinstance, 1, 0)
 		}
 	}
 

--- a/internal/memloader/loader.go
+++ b/internal/memloader/loader.go
@@ -104,7 +104,7 @@ func (l *Loader) LoadMem(data []byte) (loader.Module, error) {
 
 	// If the image is not movable, allocate it at its preferred address.
 	if bin.Header.OptionalHeader.DllCharacteristics&pe.ImageDLLCharacteristicsDynamicBase == 0 {
-		mem = l.machine.Alloc(bin.Header.OptionalHeader.ImageBase, imageSize, vmem.MemCommit|vmem.MemReserve, vmem.PageReadWrite)
+		mem = l.machine.Alloc(bin.Header.OptionalHeader.ImageBase, imageSize, vmem.MemCommit|vmem.MemReserve, vmem.PageExecuteReadWrite)
 		if mem == nil {
 			return nil, fmt.Errorf("image could not be mapped at preferred base 0x%08x and cannot be relocated", bin.Header.OptionalHeader.ImageBase)
 		}
@@ -117,7 +117,7 @@ func (l *Loader) LoadMem(data []byte) (loader.Module, error) {
 		if mem != nil {
 			failedAllocs = append(failedAllocs, mem)
 		}
-		if mem = l.machine.Alloc(0, imageSize, vmem.MemCommit|vmem.MemReserve, vmem.PageReadWrite); mem == nil {
+		if mem = l.machine.Alloc(0, imageSize, vmem.MemCommit|vmem.MemReserve, vmem.PageExecuteReadWrite); mem == nil {
 			return nil, fmt.Errorf("allocation of %d bytes failed", imageSize)
 		}
 	}


### PR DESCRIPTION
- UPX has a hack around TLS sections to defer the callbacks. We were not properly checking for null in this case.
- Memory protection was being set wrong for "empty" sections; it should affect the empty alignment area, too.
- Memory protection is set to executable for areas that are not in sections or the header. This is most likely wrong, but should try to determine what Windows Loader does if possible.

Fixes #3, unforeseen issues notwithstanding.